### PR TITLE
update UCI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
-INCLUDE(GNUInstallDirs)
 
 PROJECT(uci C)
+INCLUDE(GNUInstallDirs)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 

--- a/blob.c
+++ b/blob.c
@@ -210,12 +210,10 @@ __uci_blob_check_equal(struct blob_attr *c1, struct blob_attr *c2,
 		return true;
 
 	tb1 = alloca(config->n_params * sizeof(struct blob_attr *));
-	blobmsg_parse(config->params, config->n_params, tb1,
-		blob_data(c1), blob_len(c1));
+	blobmsg_parse_attr(config->params, config->n_params, tb1, c1);
 
 	tb2 = alloca(config->n_params * sizeof(struct blob_attr *));
-	blobmsg_parse(config->params, config->n_params, tb2,
-		blob_data(c2), blob_len(c2));
+	blobmsg_parse_attr(config->params, config->n_params, tb2, c2);
 
 	return !uci_blob_diff(tb1, tb2, config, NULL);
 }

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 PROJECT(uci C)
 
 SET(CMAKE_INSTALL_PREFIX /)


### PR DESCRIPTION
apply changes for 9033e8c27253977285bd3679311b212607b492c6 to 5e69edac2ec4d23a443de11d6f3f11912d8b2d89 from the upstream

Summary:
        - CMakeLists: fix CMake warning for INCLUDE macro
        - lua: CMakeLists: drop redundant cmake_minimum_required
        - lua: CMakeLists: update cmake minimum required version to 3.10
        - blob: use blobmsg_parse_attr in __uci_blob_check_equal
        