### PR TITLE
debian: set Rules-Requires-Root to no

### DIFF
--- a/package/debian.control
+++ b/package/debian.control
@@ -4,6 +4,7 @@ Build-Depends: cmake, debhelper (>= 9), libubox-dev
 Standards-Version: 4.5.0
 Priority: optional
 Section: admin
+Rules-Requires-Root: no
 
 Package: libuci1
 Architecture: any


### PR DESCRIPTION
Indicate to the Debian packaging system that this package does not need fakeroot to build.